### PR TITLE
Add standalone editor page navigation and song list

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
     />
     <title>Hill Rd. Setlist Manager</title>
     <link rel="stylesheet" href="style.css" />
-    <link rel="stylesheet" href="editor/editor.css" />
     <meta
       name="theme-color"
       media="(prefers-color-scheme: light)"
@@ -121,7 +120,7 @@
 
         <section id="editor" class="tab">
           <div class="page-content editor-page">
-            <div id="editor-mount" class="editor-mount"></div>
+            <div id="editor-song-list" class="song-list"></div>
           </div>
         </section>
       </main>
@@ -167,9 +166,5 @@
         });
       }
     </script>
-
-    <div id="editor-mode" class="modal" style="display: none">
-      <div class="modal-content" id="editor-overlay"></div>
-    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Show a list of available songs in the **Editor** tab
- Launch editor.html for creating or editing songs instead of modal overlay

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aea1fd1be4832a9d6002db024e4653