### PR TITLE
Center lyrics and disable chord mode by default

### DIFF
--- a/performance/performance.css
+++ b/performance/performance.css
@@ -337,7 +337,7 @@
 
 .lyrics-line-group { margin-bottom: 0.35em; }
 .lyric-text,
-.chord-line { text-align: left; }
+.chord-line { text-align: center; }
 .chord-line {
   white-space: pre;
   font-size: 0.75em;

--- a/performance/performance.html
+++ b/performance/performance.html
@@ -140,7 +140,7 @@
             ><i class="fas fa-edit"></i> Edit Mode</label
           >
           <select id="perf-edit-mode">
-            <option value="readonly">Read Only</option>
+            <option value="readonly" selected>Read Only</option>
             <option value="lyrics">Lyrics Only</option>
             <option value="chords">Chords Only</option>
             <option value="both">Both</option>
@@ -152,10 +152,10 @@
             ><i class="fas fa-guitar"></i> Chord Mode</label
           >
           <select id="perf-chord-mode">
-            <option value="off">Off</option>
+            <option value="off" selected>Off</option>
             <option value="lyrics">Lyrics Only</option>
             <option value="chords">Chords Only</option>
-            <option value="both" selected>Both</option>
+            <option value="both">Both</option>
           </select>
         </div>
 

--- a/performance/performance.js
+++ b/performance/performance.js
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
         resizeObserver: null,
 
         editMode: localStorage.getItem('perfEditMode') || 'readonly',
-        chordMode: localStorage.getItem('perfChordMode') || 'both',
+        chordMode: localStorage.getItem('perfChordMode') || 'off',
 
         fontSize: 32, // default value; will set per song
         perSongFontSizes: JSON.parse(localStorage.getItem('perSongFontSizes') || '{}'),


### PR DESCRIPTION
## Summary
- Center align lyrics and chords in performance view
- Set default performance mode to read-only and chord mode off
- Initialize chord mode state to "off" when none stored

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aea8d655f4832abbf518a23c7f54c0