### PR TITLE
feat: tighten app shell and caching

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,9 +1,10 @@
 "use strict";
 window.App = window.App || {};
-App.Config = {
+App.Config = Object.assign({
   APP_NAME: "Hill Rd Setlist Manager",
   VERSION: "1.0.0",
   DEBUG: true,
+  SCHEMA_VERSION: 1,
   STORAGE: {
     SONGS: "hrsm:songs",
     SETLISTS: "hrsm:setlists",
@@ -11,6 +12,6 @@ App.Config = {
     VERSION: "hrsm:version",
   },
   UI: { AUTOSCROLL_MIN_BPM: 20, AUTOSCROLL_MAX_BPM: 240 },
-};
+}, App.Config || {});
 // Backwards compatibility for legacy code expecting window.CONFIG
 window.CONFIG = App.Config;

--- a/editor.js
+++ b/editor.js
@@ -1,60 +1,68 @@
 // editor.js - bridge stub for lazy-loaded editor
-window.Editor = (() => {
-  let deps = null;
-  let containerEl = null;
+(function () {
+  "use strict";
+  window.App = window.App || {};
+  App.Editor = (() => {
+    let deps = null;
+    let containerEl = null;
 
-  function init(_deps) {
-    deps = _deps;
-  }
-
-  function open({ container, songId } = {}) {
-    containerEl = container || document.getElementById("editor-mount");
-    if (!containerEl || !deps) return;
-    const songs = deps.getSongs();
-    let song = songId
-      ? songs.find((s) => s.id === songId)
-      : { ...deps.core.DEFAULT_SONG };
-    containerEl.innerHTML = "";
-
-    const title = document.createElement("input");
-    title.type = "text";
-    title.placeholder = "Song Title";
-    title.value = song?.title || "";
-    containerEl.appendChild(title);
-
-    const textarea = document.createElement("textarea");
-    textarea.style.width = "100%";
-    textarea.style.height = "200px";
-    textarea.value = song?.lyrics || "";
-    containerEl.appendChild(textarea);
-
-    const saveBtn = document.createElement("button");
-    saveBtn.textContent = "Save";
-    saveBtn.addEventListener("click", () => {
-      const t = title.value.trim();
-      const l = textarea.value.trim();
-      if (!t && !l) {
-        alert("Cannot save an empty song.");
-        return;
-      }
-      const updated = deps.core.migrateSong({
-        ...(song || {}),
-        title: t || "Untitled",
-        lyrics: l || "",
-      });
-      const list = songs.filter((s) => s.id !== updated.id).concat([updated]);
-      deps.setSongs(list);
-      deps.onSongSaved?.(updated);
-    });
-    containerEl.appendChild(saveBtn);
-  }
-
-  function teardown() {
-    if (containerEl) {
-      containerEl.innerHTML = "";
-      containerEl = null;
+    function init(_deps) {
+      deps = _deps;
     }
-  }
 
-  return { init, open, teardown };
+    function open({ container, songId } = {}) {
+      containerEl = container || document.getElementById("editor-mount");
+      if (!containerEl || !deps) return;
+      const songs = deps.getSongs();
+      let song = songId
+        ? songs.find((s) => s.id === songId)
+        : { ...deps.core.DEFAULT_SONG };
+      containerEl.innerHTML = "";
+
+      const title = document.createElement("input");
+      title.type = "text";
+      title.placeholder = "Song Title";
+      title.value = song?.title || "";
+      containerEl.appendChild(title);
+
+      const textarea = document.createElement("textarea");
+      textarea.style.width = "100%";
+      textarea.style.height = "200px";
+      textarea.value = song?.lyrics || "";
+      containerEl.appendChild(textarea);
+
+      const saveBtn = document.createElement("button");
+      saveBtn.textContent = "Save";
+      saveBtn.addEventListener("click", () => {
+        const t = title.value.trim();
+        const l = textarea.value.trim();
+        if (!t && !l) {
+          alert("Cannot save an empty song.");
+          return;
+        }
+        const updated = deps.core.migrateSong({
+          ...(song || {}),
+          title: t || "Untitled",
+          lyrics: l || "",
+        });
+        const list = songs
+          .filter((s) => s.id !== updated.id)
+          .concat([updated]);
+        deps.setSongs(list);
+        deps.onSongSaved?.(updated);
+      });
+      containerEl.appendChild(saveBtn);
+    }
+
+    function teardown() {
+      if (containerEl) {
+        containerEl.innerHTML = "";
+        containerEl = null;
+      }
+    }
+
+    return { init, open, teardown };
+  })();
+
+  window.Editor = App.Editor;
 })();

--- a/editor/editor.css
+++ b/editor/editor.css
@@ -878,3 +878,12 @@
     padding: 0;
     border-radius: 50%;
 }
+
+/* offline banner */
+.offline-banner {
+    background: #c0392b;
+    color: #fff;
+    text-align: center;
+    padding: 0.5rem;
+    font-size: 0.9rem;
+}

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -31,7 +31,7 @@
       href="https://fonts.googleapis.com/css2?family=Neonderthaw&display=swap"
       rel="stylesheet"
     />
-    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
     <style>
       /* Additional styles for metadata panel */
       .metadata-panel {
@@ -90,6 +90,7 @@
     </style>
   </head>
   <body>
+    <div id="offline-banner" class="offline-banner" hidden>Offline mode: some features may be limited.</div>
     <div id="editor-mode" class="editor-mode-overlay">
       <header id="app-header">
         <div class="header-left">
@@ -448,7 +449,15 @@
     <script defer>
       if ("serviceWorker" in navigator) {
         window.addEventListener("load", () => {
-          navigator.serviceWorker.register("/sw.js").catch(() => {});
+          navigator.serviceWorker.register("/sw.js")
+            .then((r) => console.log("sw: registered", r.scope))
+            .catch((err) => console.log("sw: failed", err));
+        });
+        let refreshing = false;
+        navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (refreshing) return;
+          refreshing = true;
+          window.location.reload();
         });
       }
     </script>

--- a/editor/songs.js
+++ b/editor/songs.js
@@ -1,4 +1,7 @@
-const SCHEMA_VERSION = 1;
+ (function () {
+"use strict";
+window.App = window.App || {};
+const SCHEMA_VERSION = App.Config && App.Config.SCHEMA_VERSION || 1;
 // Enhanced song data structure with metadata
 const defaultSections = "[Intro]\n\n[Verse 1]\n\n[Pre-Chorus]\n\n[Chorus]\n\n[Verse 2]\n\n[Bridge]\n\n[Outro]";
 
@@ -346,3 +349,7 @@ async function importSongs(file) {
         throw e;
     }
 }
+
+App.Songs = Object.assign(App.Songs || {}, { create: createSong, SCHEMA_VERSION });
+App.Clipboard = App.Clipboard || ClipboardManager;
+})();

--- a/index.html
+++ b/index.html
@@ -30,12 +30,12 @@
       href="https://fonts.googleapis.com/css2?family=Neonderthaw&display=swap"
       rel="stylesheet"
     />
-    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
-    <script src="lib/mammoth.browser.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+    <script defer src="lib/mammoth.browser.min.js"></script>
   </head>
   <body>
-    <div id="offline-banner" class="offline-banner" hidden>Offline</div>
+    <div id="offline-banner" class="offline-banner" hidden>Offline mode: some features may be limited.</div>
     <div class="main-box">
       <header class="app-header">
         <div class="header-top">
@@ -164,12 +164,14 @@
     <script defer>
       if ("serviceWorker" in navigator) {
         window.addEventListener("load", () => {
-          navigator.serviceWorker
-            .register("/sw.js")
-            .then(() => console.log("sw:registered"))
-            .catch((err) => console.log("sw:failed", err));
+          navigator.serviceWorker.register("/sw.js")
+            .then((r) => console.log("sw: registered", r.scope))
+            .catch((err) => console.log("sw: failed", err));
         });
+        let refreshing = false;
         navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (refreshing) return;
+          refreshing = true;
           window.location.reload();
         });
       }

--- a/performance/performance.css
+++ b/performance/performance.css
@@ -348,3 +348,12 @@
   text-align: center;
   padding: 1rem;
 }
+
+/* offline banner */
+.offline-banner {
+  background: #c0392b;
+  color: #fff;
+  text-align: center;
+  padding: 0.5rem;
+  font-size: 0.9rem;
+}

--- a/performance/performance.html
+++ b/performance/performance.html
@@ -33,6 +33,7 @@
     />
   </head>
   <body>
+    <div id="offline-banner" class="offline-banner" hidden>Offline mode: some features may be limited.</div>
     <div
       id="performance-mode"
       class="performance-mode-overlay"
@@ -252,7 +253,15 @@
     <script defer>
       if ("serviceWorker" in navigator) {
         window.addEventListener("load", () => {
-          navigator.serviceWorker.register("/sw.js").catch(() => {});
+          navigator.serviceWorker.register("/sw.js")
+            .then((r) => console.log("sw: registered", r.scope))
+            .catch((err) => console.log("sw: failed", err));
+        });
+        let refreshing = false;
+        navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (refreshing) return;
+          refreshing = true;
+          window.location.reload();
         });
       }
     </script>

--- a/performance/performance.js
+++ b/performance/performance.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const { safeParse, log } = App.Utils || { safeParse: (s)=>{try{return JSON.parse(s);}catch{return null;}}, log: ()=>{} };
+    const { safeParse, log, once } = App.Utils || { safeParse: (s)=>{try{return JSON.parse(s);}catch{return null;}}, log: ()=>{}, once: (_,fn)=>fn() };
+    (once || ((_,fn)=>fn()))('performance-init', () => {
     const app = {
         // DOM Elements
         performanceMode: document.getElementById('performance-mode'),
@@ -692,5 +693,6 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     app.init();
+    });
 });
 

--- a/script.js
+++ b/script.js
@@ -40,24 +40,23 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 
 // ==== OFFLINE BANNER ====
-document.addEventListener(
-  "DOMContentLoaded",
-  () => {
+document.addEventListener("DOMContentLoaded", () => {
+  const { once } = App.Utils || {};
+  once && once("offline-banner", () => {
     const banner = document.getElementById("offline-banner");
     if (!banner) return;
-    const update = () => {
-      if (navigator.onLine) banner.setAttribute("hidden", "");
-      else banner.removeAttribute("hidden");
-    };
+    const update = () =>
+      navigator.onLine
+        ? banner.setAttribute("hidden", "")
+        : banner.removeAttribute("hidden");
     window.addEventListener("online", update);
     window.addEventListener("offline", update);
     update();
-  },
-  { once: true },
-);
+  });
+});
 
 // ==== SETLIST MANAGER MODULE
-function normalizeSetlistName(name) {
+App.Utils.normalizeSetlistName = function (name) {
   return name
     .replace(/\.[^/.]+$/, "") // Remove file extension
     .replace(/[_\-]+/g, " ")
@@ -66,22 +65,17 @@ function normalizeSetlistName(name) {
     .trim()
     .toLowerCase()
     .replace(/\b\w/g, (c) => c.toUpperCase());
-}
+};
 
-const SetlistsManager = (() => {
+App.Setlists = (() => {
+  const { safeParse } = App.Utils;
   let setlists = new Map();
   const DB_KEY = "setlists";
 
   function load() {
-    try {
-      const raw = localStorage.getItem(DB_KEY);
-      if (raw) {
-        const arr = JSON.parse(raw);
-        setlists = new Map(arr.map((obj) => [obj.id, obj]));
-      }
-    } catch (error) {
-      setlists = new Map();
-    }
+    const raw = localStorage.getItem(DB_KEY);
+    const arr = safeParse(raw, []);
+    setlists = new Map(arr.map((obj) => [obj.id, obj]));
   }
 
   function save() {
@@ -99,7 +93,7 @@ const SetlistsManager = (() => {
   }
 
   function addSetlist(name, songIds = []) {
-    const normalized = normalizeSetlistName(name);
+    const normalized = App.Utils.normalizeSetlistName(name);
     const existing = Array.from(setlists.values()).find(
       (s) => s.name.toLowerCase() === normalized.toLowerCase(),
     );
@@ -131,7 +125,7 @@ const SetlistsManager = (() => {
   function renameSetlist(id, newName) {
     const setlist = setlists.get(id);
     if (setlist) {
-      const normalized = normalizeSetlistName(newName);
+      const normalized = App.Utils.normalizeSetlistName(newName);
       const existing = Array.from(setlists.values()).find(
         (s) => s.id !== id && s.name.toLowerCase() === normalized.toLowerCase(),
       );
@@ -211,7 +205,7 @@ const SetlistsManager = (() => {
 
   function importSetlistFromText(name, text, allSongs) {
     // Normalize and trim setlist name
-    const normalizedName = name.trim();
+    const normalizedName = App.Utils.normalizeSetlistName(name);
     if (!normalizedName) {
       alert("Setlist name cannot be empty.");
       return null;
@@ -250,7 +244,7 @@ const SetlistsManager = (() => {
     // Add setlist with fuzzy matched songs
     let setlist;
     try {
-      setlist = SetlistsManager.addSetlist(normalizedName, songIds);
+      setlist = App.Setlists.addSetlist(normalizedName, songIds);
     } catch (err) {
       alert(err.message || "Failed to create setlist.");
       return null;
@@ -487,7 +481,7 @@ document.addEventListener("DOMContentLoaded", () => {
             }
             const format = prompt("Export format? (json/txt/csv)", "json");
             if (!format) return;
-            const content = SetlistsManager.exportSetlist(
+            const content = App.Setlists.exportSetlist(
               this.currentSetlistId,
               this.songs,
               format.trim().toLowerCase(),
@@ -495,7 +489,7 @@ document.addEventListener("DOMContentLoaded", () => {
             if (content) {
               let ext =
                 format === "csv" ? "csv" : format === "txt" ? "txt" : "json";
-              const setlist = SetlistsManager.getSetlistById(
+              const setlist = App.Setlists.getSetlistById(
                 this.currentSetlistId,
               );
               const name = setlist
@@ -584,7 +578,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Data Management
     loadData() {
-      this.songs = JSON.parse(localStorage.getItem("songs")) || [];
+      const raw = localStorage.getItem("songs");
+      this.songs = App.Utils.safeParse(raw, []);
       const theme = localStorage.getItem("theme") || "dark";
       document.documentElement.dataset.theme = theme;
     },
@@ -799,8 +794,8 @@ document.addEventListener("DOMContentLoaded", () => {
     deleteSong(id) {
       if (confirm("Are you sure you want to delete this song?")) {
         this.removeLyric(id);
-        SetlistsManager.getAllSetlists().forEach((s) => {
-          SetlistsManager.removeSongFromSetlist(s.id, id);
+        App.Setlists.getAllSetlists().forEach((s) => {
+          App.Setlists.removeSongFromSetlist(s.id, id);
         });
         this.renderSongs();
         this.renderSetlists();
@@ -851,7 +846,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Setlist Management
     renderSetlists() {
-      const setlists = SetlistsManager.getAllSetlists();
+      const setlists = App.Setlists.getAllSetlists();
       if (this.setlistSelect) {
         this.setlistSelect.innerHTML =
           '<option value="">Select a setlist...</option>';
@@ -895,7 +890,7 @@ document.addEventListener("DOMContentLoaded", () => {
     },
 
     renderSetlistSongs() {
-      const setlist = SetlistsManager.getSetlistById(this.currentSetlistId);
+      const setlist = App.Setlists.getSetlistById(this.currentSetlistId);
       const allSongs = this.songs;
 
       if (!setlist) {
@@ -957,7 +952,7 @@ document.addEventListener("DOMContentLoaded", () => {
             const newOrder = Array.from(
               this.currentSetlistSongsContainer.querySelectorAll(".song-item"),
             ).map((item) => item.dataset.id);
-            SetlistsManager.updateSetlistSongs(this.currentSetlistId, newOrder);
+            App.Setlists.updateSetlistSongs(this.currentSetlistId, newOrder);
             this.renderSetlistSongs();
           },
         },
@@ -967,7 +962,7 @@ document.addEventListener("DOMContentLoaded", () => {
     openSetlistModal(mode = "add") {
       this.modalMode = mode;
       if (mode === "rename" && this.currentSetlistId) {
-        const setlist = SetlistsManager.getSetlistById(this.currentSetlistId);
+        const setlist = App.Setlists.getSetlistById(this.currentSetlistId);
         this.setlistModalTitle.textContent = "Rename Setlist";
         this.setlistNameInput.value = setlist?.name || "";
       } else {
@@ -992,9 +987,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
       try {
         if (this.modalMode === "rename" && this.currentSetlistId) {
-          SetlistsManager.renameSetlist(this.currentSetlistId, name);
+          App.Setlists.renameSetlist(this.currentSetlistId, name);
         } else {
-          const setlist = SetlistsManager.addSetlist(name, []);
+          const setlist = App.Setlists.addSetlist(name, []);
           this.currentSetlistId = setlist.id;
         }
       } catch (err) {
@@ -1007,7 +1002,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     handleDuplicateSetlist() {
       if (!this.currentSetlistId) return;
-      const newSetlist = SetlistsManager.duplicateSetlist(
+      const newSetlist = App.Setlists.duplicateSetlist(
         this.currentSetlistId,
       );
       if (newSetlist) {
@@ -1019,7 +1014,7 @@ document.addEventListener("DOMContentLoaded", () => {
     handleDeleteSetlist() {
       if (!this.currentSetlistId) return;
       if (confirm("Delete this setlist?")) {
-        SetlistsManager.deleteSetlist(this.currentSetlistId);
+        App.Setlists.deleteSetlist(this.currentSetlistId);
         this.currentSetlistId = null;
         this.renderSetlists();
       }
@@ -1035,7 +1030,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const songItem = e.target.closest(".song-item");
       if (!songItem || !this.currentSetlistId) return;
       const id = songItem.dataset.id;
-      SetlistsManager.addSongToSetlist(this.currentSetlistId, id);
+      App.Setlists.addSongToSetlist(this.currentSetlistId, id);
       this.renderSetlistSongs();
     },
 
@@ -1044,13 +1039,13 @@ document.addEventListener("DOMContentLoaded", () => {
       if (!songItem || !this.currentSetlistId) return;
       const id = songItem.dataset.id;
       if (e.target.closest(".remove-from-setlist-btn")) {
-        SetlistsManager.removeSongFromSetlist(this.currentSetlistId, id);
+        App.Setlists.removeSongFromSetlist(this.currentSetlistId, id);
         this.renderSetlistSongs();
       } else if (e.target.closest(".move-up-btn")) {
-        SetlistsManager.moveSongInSetlist(this.currentSetlistId, id, -1);
+        App.Setlists.moveSongInSetlist(this.currentSetlistId, id, -1);
         this.renderSetlistSongs();
       } else if (e.target.closest(".move-down-btn")) {
-        SetlistsManager.moveSongInSetlist(this.currentSetlistId, id, 1);
+        App.Setlists.moveSongInSetlist(this.currentSetlistId, id, 1);
         this.renderSetlistSongs();
       }
     },
@@ -1075,7 +1070,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const query = this.performanceSongSearch.value.trim();
 
       if (this.performanceSetlistId) {
-        const setlist = SetlistsManager.getSetlistById(
+        const setlist = App.Setlists.getSetlistById(
           this.performanceSetlistId,
         );
         if (setlist) {
@@ -1117,7 +1112,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     handleStartPerformance() {
       if (this.performanceSetlistId) {
-        const setlist = SetlistsManager.getSetlistById(
+        const setlist = App.Setlists.getSetlistById(
           this.performanceSetlistId,
         );
         if (setlist && setlist.songs.length > 0) {
@@ -1220,7 +1215,7 @@ document.addEventListener("DOMContentLoaded", () => {
   app.init();
 
   function finishImportSetlist(name, text) {
-    const result = SetlistsManager.importSetlistFromText(name, text, app.songs);
+    const result = App.Setlists.importSetlistFromText(name, text, app.songs);
     if (result) {
       app.currentSetlistId = result.setlist.id;
       app.renderSetlists();

--- a/utils.js
+++ b/utils.js
@@ -2,9 +2,12 @@
 window.App = window.App || {};
 App.Utils = (() => {
   const DEBUG = !!(window.App && App.Config && App.Config.DEBUG);
-  const log = (...args) => { if (DEBUG) console.log(...args); };
-  const safeParse = (s, fallback=null) => {
+  const log = (...a) => { if (DEBUG) console.log("[App]", ...a); };
+  const safeParse = (s, fallback = null) => {
     try { return JSON.parse(s); } catch { return fallback; }
   };
-  return { log, safeParse };
+  // simple once() guard for idempotent init
+  const onceFlags = new Set();
+  const once = (key, fn) => { if (onceFlags.has(key)) return; onceFlags.add(key); fn(); };
+  return { log, safeParse, once };
 })();


### PR DESCRIPTION
## Summary
- centralize utils with debug logging, safe JSON parsing, and once() guards
- normalize script loading and service worker registration across pages
- move setlist logic into `App` namespace and harden offline handling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af428eade0832ab146642db91e0a8d