### PR TITLE
chore: unify globals and improve offline

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,16 +1,20 @@
 "use strict";
 window.App = window.App || {};
-App.Config = {
-  APP_NAME: "Hill Rd Setlist Manager",
-  VERSION: "1.0.0",
-  DEBUG: true,
-  STORAGE: {
-    SONGS: "hrsm:songs",
-    SETLISTS: "hrsm:setlists",
-    SETTINGS: "hrsm:settings",
-    VERSION: "hrsm:version",
+App.Config = Object.assign(
+  {
+    APP_NAME: "Hill Rd Setlist Manager",
+    VERSION: "1.0.0",
+    DEBUG: true,
+    SCHEMA_VERSION: 1,
+    STORAGE: {
+      SONGS: "hrsm:songs",
+      SETLISTS: "hrsm:setlists",
+      SETTINGS: "hrsm:settings",
+      VERSION: "hrsm:version",
+    },
+    UI: { AUTOSCROLL_MIN_BPM: 20, AUTOSCROLL_MAX_BPM: 240 },
   },
-  UI: { AUTOSCROLL_MIN_BPM: 20, AUTOSCROLL_MAX_BPM: 240 },
-};
+  App.Config || {},
+);
 // Backwards compatibility for legacy code expecting window.CONFIG
 window.CONFIG = App.Config;

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -31,7 +31,7 @@
       href="https://fonts.googleapis.com/css2?family=Neonderthaw&display=swap"
       rel="stylesheet"
     />
-    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
     <style>
       /* Additional styles for metadata panel */
       .metadata-panel {
@@ -90,6 +90,7 @@
     </style>
   </head>
   <body>
+    <div id="offline-banner" class="offline-banner" hidden>Offline mode: some features may be limited.</div>
     <div id="editor-mode" class="editor-mode-overlay">
       <header id="app-header">
         <div class="header-left">
@@ -448,7 +449,15 @@
     <script defer>
       if ("serviceWorker" in navigator) {
         window.addEventListener("load", () => {
-          navigator.serviceWorker.register("/sw.js").catch(() => {});
+          navigator.serviceWorker.register("/sw.js")
+            .then(r => console.log("sw: registered", r.scope))
+            .catch(err => console.log("sw: failed", err));
+        });
+        let refreshing = false;
+        navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (refreshing) return;
+          refreshing = true;
+          window.location.reload();
         });
       }
     </script>

--- a/editor/songs.js
+++ b/editor/songs.js
@@ -1,4 +1,7 @@
-const SCHEMA_VERSION = 1;
+(function(){
+"use strict";
+window.App = window.App || {};
+const SCHEMA_VERSION = App.Config?.SCHEMA_VERSION || 1;
 // Enhanced song data structure with metadata
 const defaultSections = "[Intro]\n\n[Verse 1]\n\n[Pre-Chorus]\n\n[Chorus]\n\n[Verse 2]\n\n[Bridge]\n\n[Outro]";
 
@@ -346,3 +349,7 @@ async function importSongs(file) {
         throw e;
     }
 }
+
+App.Songs = Object.assign(App.Songs || {}, { create: createSong, importSongs });
+App.Clipboard = ClipboardManager;
+})();

--- a/index.html
+++ b/index.html
@@ -30,12 +30,12 @@
       href="https://fonts.googleapis.com/css2?family=Neonderthaw&display=swap"
       rel="stylesheet"
     />
-    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
-    <script src="lib/mammoth.browser.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+    <script defer src="lib/mammoth.browser.min.js"></script>
   </head>
   <body>
-    <div id="offline-banner" class="offline-banner" hidden>Offline</div>
+    <div id="offline-banner" class="offline-banner" hidden>Offline mode: some features may be limited.</div>
     <div class="main-box">
       <header class="app-header">
         <div class="header-top">
@@ -164,12 +164,14 @@
     <script defer>
       if ("serviceWorker" in navigator) {
         window.addEventListener("load", () => {
-          navigator.serviceWorker
-            .register("/sw.js")
-            .then(() => console.log("sw:registered"))
-            .catch((err) => console.log("sw:failed", err));
+          navigator.serviceWorker.register("/sw.js")
+            .then(r => console.log("sw: registered", r.scope))
+            .catch(err => console.log("sw: failed", err));
         });
+        let refreshing = false;
         navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (refreshing) return;
+          refreshing = true;
           window.location.reload();
         });
       }

--- a/performance/performance.html
+++ b/performance/performance.html
@@ -33,6 +33,7 @@
     />
   </head>
   <body>
+    <div id="offline-banner" class="offline-banner" hidden>Offline mode: some features may be limited.</div>
     <div
       id="performance-mode"
       class="performance-mode-overlay"
@@ -252,7 +253,15 @@
     <script defer>
       if ("serviceWorker" in navigator) {
         window.addEventListener("load", () => {
-          navigator.serviceWorker.register("/sw.js").catch(() => {});
+          navigator.serviceWorker.register("/sw.js")
+            .then(r => console.log("sw: registered", r.scope))
+            .catch(err => console.log("sw: failed", err));
+        });
+        let refreshing = false;
+        navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (refreshing) return;
+          refreshing = true;
+          window.location.reload();
         });
       }
     </script>

--- a/sw.js
+++ b/sw.js
@@ -1,99 +1,67 @@
 "use strict";
-const CACHE_VERSION = "v11"; // bump on SW-relevant changes
-const STATIC_CACHE = `hrsm-static-${CACHE_VERSION}`;
-const RUNTIME_CACHE = `hrsm-runtime-${CACHE_VERSION}`;
-const STATIC_ASSETS = [
-  "/",
-  "/index.html",
-  "/editor/editor.html",
-  "/performance/performance.html",
-  "/style.css",
-  "/editor/editor.css",
-  "/performance/performance.css",
-  "/script.js",
-  "/editor/editor.js",
-  "/performance/performance.js",
-  "/core/song-core.js",
-  "/editor/songs.js",
-  "/config.js",
-  "/manifest.json",
-  "/assets/offline.html",
-  "/assets/favicon.svg",
-];
-// install: pre-cache app shell
-self.addEventListener("install", (e) => {
-  e.waitUntil(
+const CACHE_VERSION = "v11"; // bump on SW-related changes
+const STATIC_CACHE = `static-${CACHE_VERSION}`;
+const RUNTIME_CACHE = `runtime-${CACHE_VERSION}`;
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
     caches
       .open(STATIC_CACHE)
-      .then((c) => c.addAll(STATIC_ASSETS))
-      .then(() => self.skipWaiting()),
+      .then((cache) =>
+        cache.addAll([
+          "/",
+          "/index.html",
+          "/editor/editor.html",
+          "/performance/performance.html",
+          "/style.css",
+          "/editor/editor.css",
+          "/performance/performance.css",
+          "/config.js",
+          "/utils.js",
+          "/script.js",
+          "/editor/editor.js",
+          "/performance/performance.js",
+          "/core/song-core.js",
+          "/editor/songs.js",
+        ])
+      )
+      .then(() => self.skipWaiting())
   );
 });
-// activate: clean old caches + claim
-self.addEventListener("activate", (e) => {
-  e.waitUntil(
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
     caches
       .keys()
       .then((keys) =>
         Promise.all(
           keys
             .filter((k) => ![STATIC_CACHE, RUNTIME_CACHE].includes(k))
-            .map((k) => caches.delete(k)),
-        ),
+            .map((k) => caches.delete(k))
+        )
       )
-      .then(() => self.clients.claim()),
+      .then(() => self.clients.claim())
   );
 });
-// fetch handler
-self.addEventListener("fetch", (e) => {
-  const req = e.request;
-  const url = new URL(req.url);
-  if (url.origin !== self.location.origin) return;
+
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
   if (req.mode === "navigate") {
-    e.respondWith(
-      fetch(req).catch(() => caches.match("/assets/offline.html")),
-    );
+    event.respondWith(fetch(req).catch(() => caches.match("/index.html")));
     return;
   }
-  if (STATIC_ASSETS.includes(url.pathname)) {
-    e.respondWith(
-      caches.match(req).then(
-        (hit) =>
-          hit ||
-          fetch(req).then((res) => {
-            const copy = res.clone();
-            caches.open(STATIC_CACHE).then((c) => c.put(req, copy));
-            return res;
-          }),
-      ),
-    );
-    return;
-  }
-  if (req.url.endsWith(".json")) {
-    e.respondWith(
+  if (req.method === "GET" && new URL(req.url).origin === self.location.origin) {
+    event.respondWith(
       caches.match(req).then((hit) => {
-        if (hit) return hit;
-        return fetch(req)
+        const fetcher = fetch(req)
           .then((res) => {
             const copy = res.clone();
             caches.open(RUNTIME_CACHE).then((c) => c.put(req, copy));
             return res;
           })
-          .catch(() => caches.match("/assets/offline.html"));
-      }),
+          .catch(() => hit);
+        return hit || fetcher;
+      })
     );
-    return;
   }
-  e.respondWith(
-    caches.match(req).then((hit) => {
-      const fetcher = fetch(req)
-        .then((res) => {
-          const copy = res.clone();
-          caches.open(RUNTIME_CACHE).then((c) => c.put(req, copy));
-          return res;
-        })
-        .catch(() => hit);
-      return hit || fetcher;
-    }),
-  );
 });

--- a/utils.js
+++ b/utils.js
@@ -2,9 +2,18 @@
 window.App = window.App || {};
 App.Utils = (() => {
   const DEBUG = !!(window.App && App.Config && App.Config.DEBUG);
-  const log = (...args) => { if (DEBUG) console.log(...args); };
-  const safeParse = (s, fallback=null) => {
-    try { return JSON.parse(s); } catch { return fallback; }
-  };
-  return { log, safeParse };
+  const log = (...a) => { if (DEBUG) console.log("[App]", ...a); };
+  const safeParse = (s, fallback = null) => { try { return JSON.parse(s); } catch { return fallback; } };
+  const onceFlags = new Set();
+  const once = (key, fn) => { if (onceFlags.has(key)) return; onceFlags.add(key); fn(); };
+  const normalizeSetlistName = (name) =>
+    name
+      .replace(/\.[^/.]+$/, "")
+      .replace(/[_\-]+/g, " ")
+      .replace(/[^\w\s]/g, "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .toLowerCase()
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+  return { log, safeParse, once, normalizeSetlistName };
 })();


### PR DESCRIPTION
## Summary
- centralize configuration and utilities under `App` namespace
- show offline status across pages and defer script loading for consistency
- revamp service worker with versioned caches and offline-first fetch

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af428eade0832ab146642db91e0a8d