### PR TITLE
Handle null in safeParse to prevent editor crash

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -2,10 +2,23 @@
 window.App = window.App || {};
 App.Utils = (() => {
   const DEBUG = !!(window.App && App.Config && App.Config.DEBUG);
-  const log = (...a) => { if (DEBUG) console.log("[App]", ...a); };
-  const safeParse = (s, fallback = null) => { try { return JSON.parse(s); } catch { return fallback; } };
+  const log = (...a) => {
+    if (DEBUG) console.log("[App]", ...a);
+  };
+  const safeParse = (s, fallback = null) => {
+    if (s == null) return fallback;
+    try {
+      return JSON.parse(s);
+    } catch {
+      return fallback;
+    }
+  };
   const onceFlags = new Set();
-  const once = (key, fn) => { if (onceFlags.has(key)) return; onceFlags.add(key); fn(); };
+  const once = (key, fn) => {
+    if (onceFlags.has(key)) return;
+    onceFlags.add(key);
+    fn();
+  };
   const normalizeSetlistName = (name) =>
     name
       .replace(/\.[^/.]+$/, "")


### PR DESCRIPTION
## Summary
- Avoid null dereference by returning fallback in `safeParse` when localStorage entry is missing
- Keep formatting via Prettier

## Testing
- `npx prettier utils.js -w`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af4d028408832a90344431d9c87c45